### PR TITLE
no queue callback

### DIFF
--- a/lib/function.js
+++ b/lib/function.js
@@ -1,5 +1,6 @@
 var utils = module.exports;
 var slice = Array.prototype.slice;
+var noOp = function() {};
 
 /**
  * delicious curry - crates a new function, based on a target function,
@@ -61,6 +62,7 @@ utils.queueUntilReady = function(prepare, onReady) {
   };
 
   onReady = onReady || function(callback) {
+    callback = callback || noOp;
     callback();
   };
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "picu",
   "description": "PICU is Caarbon's [Node] Utilities",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "main": "./lib",
   "scripts": {
     "test": "grunt lint && mocha -R dot -t 20000 -b --recursive ./test"


### PR DESCRIPTION
Sometimes we need to start up a queue before using it.

E.g.

```js
var queued = utils.queueUntilReady(function(done) {
  // ... things happen
  done();
});

queued();

module.exports = function(callback) {
  queued(function() {
    callback();
  });
};
```

Before, running `queued()` would have failed