### PR TITLE
allowing better str.replace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PICU [![Circle CI](https://circleci.com/gh/caarbon/picu.svg?style=svg)](https://circleci.com/gh/caarbon/picu)
 
-PICU is Caarbon's [Node] Utilities
+PICU is Carbon's [Node] Utilities
 
 Utilities will be added as they are needed.
 

--- a/lib/string.js
+++ b/lib/string.js
@@ -118,11 +118,11 @@ utils.pad = function(string, length, chr) {
  * @return {String}              Resulting string
  */
 utils.replace = function(template, replacements, pattern) {
-  pattern = pattern || /\{\{([\w\(\)]+)\}\}/g;
+  pattern = pattern || /\{\{([^\}]+)\}\}/g;
 
   return template.replace(pattern, function(match, key) {
     var func, val;
-    var callingFunc = /^(\w+)\((\w+)\)$/.exec(key);
+    var callingFunc = /^([^\(]+)\(([^\)]+)\)$/.exec(key);
 
     if (callingFunc) {
       func = replacements[ callingFunc[1] ];

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "picu",
-  "description": "PICU is Caarbon's [Node] Utilities",
-  "version": "0.1.0",
+  "description": "PICU is Carbon's [Node] Utilities",
+  "author": "Tim Marshall <timothyjmarshall@gmail.com>",
+  "version": "0.1.1",
   "main": "./lib",
   "scripts": {
     "test": "grunt lint && mocha -R dot -t 20000 -b --recursive ./test"
@@ -16,5 +17,11 @@
     "matchdep": "0.3.0",
     "mocha": "2.1.0"
   },
-  "repository": "git://github.com/caarbon/director"
+  "homepage": "https://github.com/caarbon/picu",
+  "repository": "git://github.com/caarbon/picu",
+  "bugs": {
+    "url": "https://github.com/caarbon/picu/issues"
+  },
+  "license": "ISC",
+  "keywords": ["node", "utils", "picu"]
 }

--- a/test/string.js
+++ b/test/string.js
@@ -165,10 +165,10 @@ describe('String Utils module', function() {
 
   describe('.replace(template, replacements, pattern)', function() {
     it('should prepare a string correctly', function() {
-      var result = utils.replace('~name~ is a ~creature~. ~name~ likes ~food~.', {
+      var result = utils.replace('~name~ is a ~creature~. ~name~ likes ~food.stuff~.', {
         name: 'Benedict',
         creature: 'bear',
-        food: 'fish'
+        'food.stuff': 'fish'
       }, /~([^~]+)~/g);
 
       assert.equal(result, 'Benedict is a bear. Benedict likes fish.');


### PR DESCRIPTION
Before we were allowing word characters (`[a-zA-Z0-9]`) and `()` parenthesis.

This broke things when you had a replacement obj like `{ 'my.thing': 'my replacement' }` since the `.` caused the replacement to be ignored